### PR TITLE
adding a prometheus collector to continuously update metrics

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+
+	tfe "github.com/DeviaVir/go-tfe"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+type tfeCollector struct {
+	runsTotalMetric          *prometheus.Desc
+	runsPendingMetric        *prometheus.Desc
+	runsPlanningMetric       *prometheus.Desc
+	runsPlannedMetric        *prometheus.Desc
+	runsConfirmedMetric      *prometheus.Desc
+	runsApplyingMetric       *prometheus.Desc
+	runsAppliedMetric        *prometheus.Desc
+	runsDiscardedMetric      *prometheus.Desc
+	runsErroredMetric        *prometheus.Desc
+	runsCanceledMetric       *prometheus.Desc
+	runsPolicyCheckingMetric *prometheus.Desc
+	runsPolicyOverrideMetric *prometheus.Desc
+	runsPolicyCheckedMetric  *prometheus.Desc
+}
+
+// newTFECollector initializes every descriptor and returns a pointer to the collector
+func NewTfeCollector() *tfeCollector {
+	return &tfeCollector{
+		runsTotalMetric: prometheus.NewDesc("runs_total",
+			"Total number of runs with any status (total)",
+			nil, nil,
+		),
+		runsPendingMetric: prometheus.NewDesc("runs_pending",
+			"Runs currently in the queue (pending)",
+			nil, nil,
+		),
+		runsPlanningMetric: prometheus.NewDesc("runs_planning",
+			"Runs currently planning (planning)",
+			nil, nil,
+		),
+		runsPlannedMetric: prometheus.NewDesc("runs_planned",
+			"Runs planned (planned)",
+			nil, nil,
+		),
+		runsConfirmedMetric: prometheus.NewDesc("runs_confirmed",
+			"Runs confirmed (confirmed)",
+			nil, nil,
+		),
+		runsApplyingMetric: prometheus.NewDesc("runs_applying",
+			"Runs currently applying (applying)",
+			nil, nil,
+		),
+		runsAppliedMetric: prometheus.NewDesc("runs_applied",
+			"Runs applied (applied)",
+			nil, nil,
+		),
+		runsDiscardedMetric: prometheus.NewDesc("runs_discarded",
+			"Runs discarded (discarded)",
+			nil, nil,
+		),
+		runsErroredMetric: prometheus.NewDesc("runs_errored",
+			"Runs errored (errored)",
+			nil, nil,
+		),
+		runsCanceledMetric: prometheus.NewDesc("runs_canceled",
+			"Runs canceled (canceled)",
+			nil, nil,
+		),
+		runsPolicyCheckingMetric: prometheus.NewDesc("runs_policy_checking",
+			"Runs currently checking policy (policy-checking)",
+			nil, nil,
+		),
+		runsPolicyOverrideMetric: prometheus.NewDesc("runs_policy_override",
+			"Runs with overriden policy (policy-override)",
+			nil, nil,
+		),
+		runsPolicyCheckedMetric: prometheus.NewDesc("runs_policy_checked",
+			"Runs with checked policy (policy-checked)",
+			nil, nil,
+		),
+	}
+}
+
+// Describe essentially writes all descriptors to the prometheus desc channel.
+func (collector *tfeCollector) Describe(ch chan<- *prometheus.Desc) {
+
+	ch <- collector.runsTotalMetric
+	ch <- collector.runsPendingMetric
+	ch <- collector.runsPlanningMetric
+	ch <- collector.runsPlannedMetric
+	ch <- collector.runsConfirmedMetric
+	ch <- collector.runsApplyingMetric
+	ch <- collector.runsAppliedMetric
+	ch <- collector.runsDiscardedMetric
+	ch <- collector.runsErroredMetric
+	ch <- collector.runsCanceledMetric
+	ch <- collector.runsPolicyCheckingMetric
+	ch <- collector.runsPolicyOverrideMetric
+	ch <- collector.runsPolicyCheckedMetric
+}
+
+// tfeClients returns a List all the runs of the terraform enterprise installation
+func tfeRuns(tfeToken, tfeAddress string) (*tfe.AdminRunsList, error) {
+
+	config := &tfe.Config{
+		Token:   tfeToken,
+		Address: tfeAddress,
+	}
+	ctx := context.Background()
+	client, err := tfe.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	options := tfe.ListOptions{
+		PageNumber: 1,
+		PageSize:   1,
+	}
+	runs, err := client.AdminRuns.List(
+		ctx, tfe.AdminRunsListOptions{ListOptions: options})
+	if err != nil {
+		return nil, err
+	}
+
+	return runs, nil
+}
+
+//Collect implements required collect function for all promehteus collectors
+func (collector *tfeCollector) Collect(ch chan<- prometheus.Metric) {
+
+	log.Println("[INFO]: scraping metrics")
+
+	// runs retrieves a List all the runs of TFE.
+	runs, err := tfeRuns(TfeToken, TfeAddress)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//Write latest value for each metric in the prometheus metric channel.
+	ch <- prometheus.MustNewConstMetric(collector.runsTotalMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Total))
+	ch <- prometheus.MustNewConstMetric(collector.runsPendingMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Pending))
+	ch <- prometheus.MustNewConstMetric(collector.runsPlanningMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Planning))
+	ch <- prometheus.MustNewConstMetric(collector.runsPlannedMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Planned))
+	ch <- prometheus.MustNewConstMetric(collector.runsConfirmedMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Confirmed))
+	ch <- prometheus.MustNewConstMetric(collector.runsApplyingMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Applying))
+	ch <- prometheus.MustNewConstMetric(collector.runsAppliedMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Applied))
+	ch <- prometheus.MustNewConstMetric(collector.runsDiscardedMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Discarded))
+	ch <- prometheus.MustNewConstMetric(collector.runsErroredMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Errored))
+	ch <- prometheus.MustNewConstMetric(collector.runsCanceledMetric, prometheus.GaugeValue, float64(runs.StatusCounts.Canceled))
+	ch <- prometheus.MustNewConstMetric(collector.runsPolicyCheckingMetric, prometheus.GaugeValue, float64(runs.StatusCounts.PolicyChecking))
+	ch <- prometheus.MustNewConstMetric(collector.runsPolicyOverrideMetric, prometheus.GaugeValue, float64(runs.StatusCounts.PolicyOverride))
+	ch <- prometheus.MustNewConstMetric(collector.runsPolicyCheckedMetric, prometheus.GaugeValue, float64(runs.StatusCounts.PolicyChecked))
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.14
 require (
 	github.com/DeviaVir/go-tfe v0.6.3
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/main.go
+++ b/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-	"context"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
-	tfe "github.com/DeviaVir/go-tfe"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+var TfeToken, TfeTokenPath, TfeAddress, VaultReadyPath string
 
 // fileExists checks if a file exists and is not a directory before we
 // try using it to prevent further errors.
@@ -41,37 +41,27 @@ func getEnvDefault(name string, defaultVal string) string {
 	return defaultVal
 }
 
-func setGauge(name string, help string, callback func() float64) {
-	gaugeFunc := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: "tf",
-		Subsystem: "enterprise",
-		Name:      name,
-		Help:      help,
-	}, callback)
-	prometheus.MustRegister(gaugeFunc)
-}
-
 func main() {
-	log.SetOutput(os.Stdout)
-	log.SetLevel(log.InfoLevel)
-	tfeToken := getEnv("TFE_TOKEN")
-	tfeTokenPath := getEnv("TFE_TOKEN_PATH")
-	tfeAddress := getEnv("TFE_ADDRESS")
-	vaultReadyPath := getEnv("VAULT_READY_PATH")
+
 	listendAddr := getEnvDefault("HTTP_LISTENADDR", ":9112")
 
-	if vaultReadyPath != "" {
+	TfeToken = getEnv("TFE_TOKEN")
+	TfeTokenPath = getEnv("TFE_TOKEN_PATH")
+	TfeAddress = getEnv("TFE_ADDRESS")
+	VaultReadyPath = getEnv("VAULT_READY_PATH")
+
+	if VaultReadyPath != "" {
 		for {
-			if fileExists(vaultReadyPath) {
+			if fileExists(VaultReadyPath) {
 				break
 			}
 			time.Sleep(1 * time.Second)
 		}
 	}
 
-	if tfeTokenPath != "" {
-		if fileExists(tfeTokenPath) {
-			path, err := homedir.Expand(tfeTokenPath)
+	if TfeTokenPath != "" {
+		if fileExists(TfeTokenPath) {
+			path, err := homedir.Expand(TfeTokenPath)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -80,69 +70,15 @@ func main() {
 				log.Fatal(err)
 			}
 
-			tfeToken = strings.TrimSpace(string(content))
+			TfeToken = strings.TrimSpace(string(content))
 		}
 	}
 
-	config := &tfe.Config{
-		Token:   tfeToken,
-		Address: tfeAddress,
-	}
-	ctx := context.Background()
-	client, err := tfe.NewClient(config)
-	if err != nil {
-		log.Fatal(err)
-	}
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.InfoLevel)
 
-	options := tfe.ListOptions{
-		PageNumber: 0,
-		PageSize:   0,
-	}
-	runs, err := client.AdminRuns.List(
-		ctx, tfe.AdminRunsListOptions{ListOptions: options})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	setGauge("runs_total", "Total number of runs with any status (total)", func() float64 {
-		return float64(runs.StatusCounts.Total)
-	})
-	setGauge("runs_pending", "Runs currently in the queue (pending)", func() float64 {
-		return float64(runs.StatusCounts.Pending)
-	})
-	setGauge("runs_planning", "Runs currently planning (planning)", func() float64 {
-		return float64(runs.StatusCounts.Planning)
-	})
-	setGauge("runs_planned", "Runs planned (planned)", func() float64 {
-		return float64(runs.StatusCounts.Planned)
-	})
-	setGauge("runs_confirmed", "Runs confirmed (confirmed)", func() float64 {
-		return float64(runs.StatusCounts.Confirmed)
-	})
-	setGauge("runs_applying", "Runs currently applying (applying)", func() float64 {
-		return float64(runs.StatusCounts.Applying)
-	})
-	setGauge("runs_applied", "Runs applied (applied)", func() float64 {
-		return float64(runs.StatusCounts.Applied)
-	})
-	setGauge("runs_discarded", "Runs discarded (discarded)", func() float64 {
-		return float64(runs.StatusCounts.Discarded)
-	})
-	setGauge("runs_errored", "Runs errored (errored)", func() float64 {
-		return float64(runs.StatusCounts.Errored)
-	})
-	setGauge("runs_canceled", "Runs canceled (canceled)", func() float64 {
-		return float64(runs.StatusCounts.Canceled)
-	})
-	setGauge("runs_policy_checking", "Runs currently checking policy (policy-checking)", func() float64 {
-		return float64(runs.StatusCounts.PolicyChecking)
-	})
-	setGauge("runs_policy_override", "Runs with overriden policy (policy-override)", func() float64 {
-		return float64(runs.StatusCounts.PolicyOverride)
-	})
-	setGauge("runs_policy_checked", "Runs with checked policy (policy-checked)", func() float64 {
-		return float64(runs.StatusCounts.PolicyChecked)
-	})
+	tfeRuns := NewTfeCollector()
+	prometheus.MustRegister(tfeRuns)
 
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -150,4 +86,5 @@ func main() {
 	})
 	log.Info("Now listening on ", listendAddr)
 	log.Fatal(http.ListenAndServe(listendAddr, nil))
+
 }


### PR DESCRIPTION
the previous version wasn't updating metrics when scrapped.
I'm adding a collector to update metrics when the prometheus exporter is getting scrapped.

proof of life:

![Screen Shot 2020-09-24 at 4 27 29 PM](https://user-images.githubusercontent.com/8475846/94296746-2f889680-ff18-11ea-8133-fda71f533833.png)
