### PR TITLE
Collect metrics per workspace

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -138,7 +138,6 @@ func getRunsByWorkspace(client *tfe.Client, ctx *context.Context, orgName string
 
 	for _, workspace := range *workspaces {
 		runs, err := client.AdminRuns.List(
-			// this is just a string match; it's probably going to choke with our service manager naming construct?
 			*ctx, tfe.AdminRunsListOptions{ListOptions: options, Query: &workspace})
 		if err != nil {
 			return nil, err

--- a/collector.go
+++ b/collector.go
@@ -26,15 +26,6 @@ type tfeCollector struct {
 
 // newTFECollector initializes every descriptor and returns a pointer to the collector
 func NewTfeCollector() *tfeCollector {
-	//workspaces, err := getWorkspaceNames(tfeToken, tfeAddress)
-	//if err != nil {
-	//	log.Fatal(err)
-	//}
-	//var workspaceLabels = make(map[string]string)
-	//for _, workspaceName := range *workspaces {
-	//	workspaceLabels["workspace"] = workspaceName
-	//}
-
 	return &tfeCollector{
 		runsTotalMetric: prometheus.NewDesc("runs_total",
 			"Total number of runs with any status (total)",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DeviaVir/tfe-prometheus-exporter
 go 1.14
 
 require (
-	github.com/DeviaVir/go-tfe v0.6.3
+	github.com/DeviaVir/go-tfe v0.6.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
 
-	tfeRuns := NewTfeCollector(TfeToken, TfeAddress)
+	tfeRuns := NewTfeCollector()
 	prometheus.MustRegister(tfeRuns)
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var TfeToken, TfeTokenPath, TfeAddress, VaultReadyPath string
+var TfeToken, TfeTokenPath, TfeAddress, TfeOrgName, VaultReadyPath string
 
 // fileExists checks if a file exists and is not a directory before we
 // try using it to prevent further errors.
@@ -49,6 +49,7 @@ func main() {
 	TfeTokenPath = getEnv("TFE_TOKEN_PATH")
 	TfeAddress = getEnv("TFE_ADDRESS")
 	VaultReadyPath = getEnv("VAULT_READY_PATH")
+	TfeOrgName = getEnv("TFE_ORG_NAME")
 
 	if VaultReadyPath != "" {
 		for {

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.InfoLevel)
 
-	tfeRuns := NewTfeCollector()
+	tfeRuns := NewTfeCollector(TfeToken, TfeAddress)
 	prometheus.MustRegister(tfeRuns)
 
 	http.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
This separates the collection of metrics by workspace, and adds a label feature to better compare rates between workspaces.